### PR TITLE
Fix bug when an HTTP route has no content

### DIFF
--- a/src/dakara_base/http_client.py
+++ b/src/dakara_base/http_client.py
@@ -391,9 +391,10 @@ class HTTPClient:
             response (requests.models.Response): response of a request.
 
         Returns:
-            dict: parsed response. None if no response was given.
+            dict: parsed response. None if no response was given or response
+            has no content.
         """
-        if response:
+        if response and response.text:
             return response.json()
 
         return None

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -408,5 +408,19 @@ class HTTPClientTestCase(TestCase):
         # call the method
         result = HTTPClient.get_json_from_response(None)
 
-        # assert the result is not None
+        # assert the result is None
+        self.assertIsNone(result)
+
+    def test_get_json_from_response_no_content(self):
+        """Test the helper to get data from a response with no content
+        """
+        # create a response with no content
+        response = MagicMock()
+        response.text = ""
+        response.json.side_effect = Exception("error")
+
+        # call the method
+        result = HTTPClient.get_json_from_response(response)
+
+        # assert the result is None
         self.assertIsNone(result)


### PR DESCRIPTION
Now, the JSON data are not extracted from the response if it has no content.