### PR TITLE
Editable authentication endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Enpoint for HTTP client authenticated is stored in `dakara_base.http_client.HTTPClient.AUTHENTICATE_ENDPOINT` and can be edited.
+  Default value was updated to `accounts/login/`.
+
 ## 1.2.0 - 2019-11-10
 
 ### Added

--- a/src/dakara_base/http_client.py
+++ b/src/dakara_base/http_client.py
@@ -59,6 +59,7 @@ class HTTPClient:
     traditional login/password mechanism.
 
     Attributes:
+        AUTHENTICATE_ENDPOINT (str): Endpoint for authentication.
         mute_raise (bool): if true, no exception will be raised when performing
             connections with the server (but authentication), only logged.
         server_url (str): URL of the server.
@@ -77,6 +78,8 @@ class HTTPClient:
         ParameterError: if critical parameters cannot be found in the
             configuration.
     """
+
+    AUTHENTICATE_ENDPOINT = "accounts/login/"
 
     def __init__(self, config, endpoint_prefix="", mute_raise=False):
         self.mute_raise = mute_raise
@@ -341,7 +344,7 @@ class HTTPClient:
             AuthenticationError: if the connection is denied or if any onther
                 error occurs.
         """
-        data = {"username": self.login, "password": self.password}
+        data = {"login": self.login, "password": self.password}
 
         def on_error(response):
             # manage failed connection response
@@ -361,7 +364,7 @@ class HTTPClient:
         logger.debug("Authenticate to the server")
         response = self.send_request_raw(
             "post",
-            "token-auth/",
+            self.AUTHENTICATE_ENDPOINT,
             message_on_error="Unable to authenticate to the server",
             function_on_error=on_error,
             json=data,

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -66,7 +66,7 @@ class HTTPClientTestCase(TestCase):
         self.url_endpoint = "http://www.example.com/api/endpoint/"
 
         # create login URL
-        self.url_login = "http://www.example.com/api/token-auth/"
+        self.url_login = "http://www.example.com/api/accounts/login/"
 
         # create a login and password
         self.login = "test"
@@ -317,7 +317,7 @@ class HTTPClientTestCase(TestCase):
 
         # call assertions
         mocked_post.assert_called_with(
-            self.url_login, json={"username": self.login, "password": self.password}
+            self.url_login, json={"login": self.login, "password": self.password}
         )
 
         # post assertions
@@ -330,7 +330,7 @@ class HTTPClientTestCase(TestCase):
             [
                 "DEBUG:dakara_base.http_client:Authenticate to the server",
                 "DEBUG:dakara_base.http_client:"
-                "Sending POST request to http://www.example.com/api/token-auth/",
+                "Sending POST request to http://www.example.com/api/accounts/login/",
                 "INFO:dakara_base.http_client:Login to server successful",
                 "DEBUG:dakara_base.http_client:Token: {}".format(self.token),
             ],


### PR DESCRIPTION
The HTTP client authentication endpoint was hard coded. This PR makes it editable and set it by default to the new value defined by this [server PR](https://github.com/DakaraProject/dakara-server/pull/138) and changes credential fields accordingly.