### PR TITLE
Drop Python 3.7 support and add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 ## Unreleased
 
+### Added
+
+- Support Python 3.12.
+
 ### Removed
 
 - Dropped Python 3.7 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 ## Unreleased
 
+### Removed
+
+- Dropped Python 3.7 support.
+
 ## 1.4.2 - 2022-11-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Collection of helper modules for the Dakara Project"
 readme = "README.md"
 license = {file = "LICENSE"}
 dynamic = ["version"]
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
         "Environment :: Console",
         "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This MR aims to drop the latest unsupported Python version (3.7) and support the latest version (3.12).