### PR TITLE
Fix ruff pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
         name: Run ruff linter
         entry: ruff check .
         language: system
+        pass_filenames: false


### PR DESCRIPTION
Fix miss-configuration of ruff pre-commit, resulting in non-Python files being checked.